### PR TITLE
Add option to disable ESI over HTTPS.

### DIFF
--- a/app/code/community/Phoenix/VarnishCache/Helper/Data.php
+++ b/app/code/community/Phoenix/VarnishCache/Helper/Data.php
@@ -20,8 +20,9 @@
 
 class Phoenix_VarnishCache_Helper_Data extends Mage_Core_Helper_Abstract
 {
-    const XML_PATH_VARNISH_CACHE_ENABLED  = 'varnishcache/general/enabled';
-    const XML_PATH_VARNISH_CACHE_DEBUG    = 'varnishcache/general/debug';
+    const XML_PATH_VARNISH_CACHE_ENABLED   = 'varnishcache/general/enabled';
+    const XML_PATH_VARNISH_CACHE_DEBUG     = 'varnishcache/general/debug';
+    const XML_PATH_VARNISH_CACHE_ESI_HTTPS = 'varnishcache/general/disable_esi_https';
 
     /**
      * Check whether Varnish cache is enabled
@@ -44,6 +45,16 @@ class Phoenix_VarnishCache_Helper_Data extends Mage_Core_Helper_Abstract
             return true;
         }
         return false;
+    }
+
+    /**
+     * Check whether ESI form key generation is enabled over HTTPS
+     *
+     * @return bool
+     */
+    public function isHttpsEsiDisabled()
+    {
+        return Mage::getStoreConfigFlag(self::XML_PATH_VARNISH_CACHE_ESI_HTTPS);
     }
 
     /**

--- a/app/code/community/Phoenix/VarnishCache/Helper/Esi.php
+++ b/app/code/community/Phoenix/VarnishCache/Helper/Esi.php
@@ -26,6 +26,16 @@ class Phoenix_VarnishCache_Helper_Esi extends Mage_Core_Helper_Abstract
     const ESI_INCLUDE_CLOSE = '" />';
 
     /**
+     * Check if ESI is disabled over HTTPS
+     *
+     * @return bool
+     */
+    protected function _isHttpsEsiDisabled()
+    {
+        return Mage::helper('varnishcache')->isHttpsEsiDisabled();
+    }
+
+    /**
      * return if used magento version uses form keys
      *
      * @return bool
@@ -44,6 +54,10 @@ class Phoenix_VarnishCache_Helper_Esi extends Mage_Core_Helper_Abstract
      */
     public function getFormKeyEsiTag()
     {
+        if($this->_isHttpsEsiDisabled() && Mage::app()->getStore()->isCurrentlySecure()) {
+            return Mage::getSingleton('core/session')->getFormKey();
+        }
+
         $url = Mage::getUrl(
             self::ESI_FORMKEY_URL,
             array(

--- a/app/code/community/Phoenix/VarnishCache/etc/config.xml
+++ b/app/code/community/Phoenix/VarnishCache/etc/config.xml
@@ -319,6 +319,7 @@ catalog_product_compare]]></disable_routes>
                 <purge_catalog_category>0</purge_catalog_category>
                 <purge_catalog_product>0</purge_catalog_product>
                 <purge_cms_page>0</purge_cms_page>
+                <disable_esi_https>0</disable_esi_https>
                 <debug>0</debug>
             </general>
         </varnishcache>

--- a/app/code/community/Phoenix/VarnishCache/etc/system.xml
+++ b/app/code/community/Phoenix/VarnishCache/etc/system.xml
@@ -165,6 +165,17 @@
                             <show_in_store>1</show_in_store>
                             <depends><enabled>1</enabled></depends>
                         </purge_cms_page>
+                        <disable_esi_https translate="label comment">
+                            <label>Disable ESI HTTPS</label>
+                            <comment>Disable ESI form key generation on secure connections.</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>140</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
+                        </disable_esi_https>
                         <debug translate="label comment">
                             <label>Debug</label>
                             <comment>Pass X-headers for debugging purpose to the client and log purge requests to /var/log/varnish_cache.log (ensure developer log is enabled).</comment>

--- a/app/locale/en_US/Phoenix_VarnishCache.csv
+++ b/app/locale/en_US/Phoenix_VarnishCache.csv
@@ -12,6 +12,8 @@
 "Disable caching","Disable caching"
 "Disable caching for routes","Disable caching for routes"
 "Disable caching vars","Disable caching vars"
+"Disable ESI HTTPS","Disable ESI HTTPS"
+"Disable ESI form key generation on secure connections.","Disable ESI form key generation on secure connections."
 "Domain or IP list separted by semicolon (e.g. host1;127.0.0.1)","Domain or IP list separted by semicolon (e.g. host1;127.0.0.1)"
 "Enable cache module","Enable cache module"
 "HTML","HTML"


### PR DESCRIPTION
I've added an option to disable the ESI form key being used when Magento is running over HTTPS. If a backend doesn't support ESI the output will break Magento. As Varnish doesn't support SSL I think this is a necessary feature.
