### PR TITLE
Fixed Access denied on latest versions of magento

### DIFF
--- a/app/code/community/Phoenix/VarnishCache/controllers/Adminhtml/VarnishCacheController.php
+++ b/app/code/community/Phoenix/VarnishCache/controllers/Adminhtml/VarnishCacheController.php
@@ -21,6 +21,11 @@
 class Phoenix_VarnishCache_Adminhtml_VarnishCacheController
     extends Mage_Adminhtml_Controller_Action
 {
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/config/varnishcache');
+    }
+    
     /**
      * get current session
      *


### PR DESCRIPTION
In our current instance due to some of the security patches, the clear varnish cache for a specific user `role` was showing access denied.