### PR TITLE
Correctly interpret isHttpsEsiDisabled

### DIFF
--- a/app/code/community/Phoenix/VarnishCache/Helper/Data.php
+++ b/app/code/community/Phoenix/VarnishCache/Helper/Data.php
@@ -105,11 +105,11 @@ class Phoenix_VarnishCache_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function isEsiCapable()
     {
-        if (false === $this->isHttpsEsiDisabled()) {
+        $request = Mage::app()->getRequest();
+        if ($request->isSecure() && $this->isHttpsEsiDisabled()) {
             return false;
         }
 
-        $request = Mage::app()->getRequest();
         $isEsiCapable = $request->getHeader(self::ESI_CAPABLE_HEADER_SIGNATURE);
         if ((false === is_null($isEsiCapable)) && ($isEsiCapable == 'on')) {
             return true;


### PR DESCRIPTION
Currently setting "Disable ESI over HTTPS" to No would actually disable ESI everywhere. I think we could actually remove the flag completely, as the ESI-capable header would only come in if Varnish was there to set it.